### PR TITLE
Fix YouTube iframe overflow on mobile

### DIFF
--- a/assets/css/signal-content.css
+++ b/assets/css/signal-content.css
@@ -201,6 +201,14 @@ img {
     border-radius: 3px;
 }
 
+/* Iframes (YouTube, etc.) */
+.content iframe,
+.e-content iframe {
+    max-width: 100%;
+    height: auto;
+    aspect-ratio: 16 / 9;
+}
+
 .content img,
 .e-content img {
     margin: 1.5rem 0;


### PR DESCRIPTION
Iframes with fixed width/height attributes (e.g. YouTube embeds) were exceeding the viewport width on mobile devices. Add max-width and aspect-ratio rules for iframes within content areas so they scale down responsively.

https://claude.ai/code/session_01X1dCNYaRtoj2mUBNcYQbHt