### PR TITLE
Add swappable Voltage colour palette (default)

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -83,6 +83,7 @@
             (function() {
                 var theme = localStorage.getItem('theme-preference') || 'auto';
                 document.documentElement.setAttribute('data-theme', theme);
+                document.documentElement.setAttribute('data-palette', localStorage.getItem('palette-preference') || 'voltage');
                 {% if instagram.colorPalette %}
                 window.__colorPalette = {{ instagram.colorPalette | dump | safe }};
                 {% endif %}

--- a/_includes/layouts/home-steno.njk
+++ b/_includes/layouts/home-steno.njk
@@ -46,6 +46,7 @@
         (function() {
             var theme = localStorage.getItem('theme-preference') || 'auto';
             document.documentElement.setAttribute('data-theme', theme);
+            document.documentElement.setAttribute('data-palette', localStorage.getItem('palette-preference') || 'voltage');
             {% if instagram.colorPalette %}
             window.__colorPalette = {{ instagram.colorPalette | dump | safe }};
             {% endif %}

--- a/_includes/partials/steno/footer.njk
+++ b/_includes/partials/steno/footer.njk
@@ -87,6 +87,12 @@
             <span class="sep">·</span>
             <button data-theme="auto" title="System preference">Auto</button>
         </div>
+        <div class="palette-toggle">
+            <span class="label">Palette</span>
+            <button data-palette="tokyo" title="Tokyo Night palette">Tokyo</button>
+            <span class="sep">·</span>
+            <button data-palette="voltage" title="Voltage palette">Voltage</button>
+        </div>
     </div>
     </div>
 </footer>

--- a/assets/css/steno.css
+++ b/assets/css/steno.css
@@ -99,6 +99,100 @@
     }
 }
 
+/* ========================================
+   Palette: Voltage — carbon black / parchment, neon spectrum, cinnabar red lead
+   Layered on top of Tokyo Night via [data-palette="voltage"].
+   Higher specificity than the default :root / [data-theme] blocks,
+   so source order is irrelevant.
+   ======================================== */
+
+:root[data-palette="voltage"] {
+    /* Dark mode (default) — carbon black + cinnabar */
+    --bg: #1a1919;            /* carbon-black */
+    --bg-tint: #262424;
+    --text: #d6d0cd;          /* dimmed parchment */
+    --text-heading: #f3efed;  /* parchment */
+    --text-muted: #8a8482;
+    --text-body: #d6d0cd;
+    --accent: #f73d3a;        /* cinnabar */
+    --accent-hover: #ff6663;
+    --border: #332f2f;
+    --border-light: #262424;
+    --code-bg: rgba(255, 255, 255, 0.04);
+    --hover-bg: rgba(247, 61, 58, 0.12);
+    --nav-text: #9a9290;
+    --footer-dim: #4a4444;
+    --footer-text: #9a9290;
+
+    /* Per-post-type accents (neon spectrum) */
+    --type-post:        #f73d3a;  /* cinnabar */
+    --type-essay:       #f3961d;  /* carrot orange */
+    --type-link:        #17ecff;  /* electric aqua */
+    --type-micro:       #bd48e8;  /* neon violet */
+    --type-quote:       #00ff95;  /* spring green */
+    --type-music:       #ee388a;  /* barbie pink */
+    --type-photography: #3740e7;  /* bright indigo */
+    --type-note:        #b0a8a4;  /* warm grey */
+}
+
+:root[data-palette="voltage"][data-theme="light"] {
+    /* Light mode — parchment + cinnabar (accents darkened for contrast) */
+    --bg: #faf8f6;            /* brightened parchment */
+    --bg-tint: #efeae7;
+    --text: #2c2828;
+    --text-heading: #1a1919;  /* carbon-black */
+    --text-muted: #8a8482;
+    --text-body: #2c2828;
+    --accent: #d62b28;        /* cinnabar (darkened) */
+    --accent-hover: #b01f1c;
+    --border: #d8d0cc;
+    --border-light: #e8e2df;
+    --code-bg: rgba(0, 0, 0, 0.04);
+    --hover-bg: rgba(214, 43, 40, 0.08);
+    --nav-text: #7a7270;
+    --footer-dim: #c4bbb6;
+    --footer-text: #2c2828;
+
+    --type-post:        #d62b28;  /* cinnabar */
+    --type-essay:       #b86a08;  /* carrot orange */
+    --type-link:        #0e8b9c;  /* electric aqua */
+    --type-micro:       #9a2fc0;  /* neon violet */
+    --type-quote:       #008f5a;  /* spring green */
+    --type-music:       #d61c6e;  /* barbie pink */
+    --type-photography: #3038d0;  /* bright indigo */
+    --type-note:        #6a6360;  /* warm grey */
+}
+
+@media (prefers-color-scheme: light) {
+    :root[data-palette="voltage"][data-theme="auto"] {
+        /* Auto-light — Voltage light */
+        --bg: #faf8f6;
+        --bg-tint: #efeae7;
+        --text: #2c2828;
+        --text-heading: #1a1919;
+        --text-muted: #8a8482;
+        --text-body: #2c2828;
+        --accent: #d62b28;
+        --accent-hover: #b01f1c;
+        --border: #d8d0cc;
+        --border-light: #e8e2df;
+        --code-bg: rgba(0, 0, 0, 0.04);
+        --hover-bg: rgba(214, 43, 40, 0.08);
+        --nav-text: #7a7270;
+        --footer-dim: #c4bbb6;
+        --footer-text: #2c2828;
+
+        --type-post:        #d62b28;
+        --type-essay:       #b86a08;
+        --type-link:        #0e8b9c;
+        --type-micro:       #9a2fc0;
+        --type-quote:       #008f5a;
+        --type-music:       #d61c6e;
+        --type-photography: #3038d0;
+        --type-note:        #6a6360;
+    }
+}
+
 /* --- Base --- */
 
 body {
@@ -151,6 +245,22 @@ hr {
 .site-banner a { color: var(--accent); }
 .site-banner a:hover { color: var(--accent-hover); }
 
+/* Voltage palette — bold cinnabar accent bar */
+:root[data-palette="voltage"] .site-banner {
+    background: #f73d3a;        /* cinnabar */
+    color: #faf8f6;            /* parchment */
+    border-bottom: none;
+    opacity: 1;
+}
+:root[data-palette="voltage"] .site-banner a {
+    color: #1a1919;            /* carbon */
+    text-decoration: underline;
+}
+:root[data-palette="voltage"] .site-banner a:hover {
+    color: #1a1919;
+    opacity: 0.7;
+}
+
 /* --- Header --- */
 
 .site-header {
@@ -197,14 +307,16 @@ hr {
 .site-nav a:hover { color: var(--accent); }
 
 /* Theme toggle (now lives in footer-bottom) */
-.theme-toggle {
+.theme-toggle,
+.palette-toggle {
     display: flex;
     gap: 0.25rem;
     align-items: center;
     font-size: var(--fs-meta);
 }
 
-.theme-toggle button {
+.theme-toggle button,
+.palette-toggle button {
     background: none;
     border: none;
     color: var(--text-muted);
@@ -214,8 +326,10 @@ hr {
     padding: 0.15rem 0.3rem;
 }
 
-.theme-toggle button:hover { color: var(--accent); }
-.theme-toggle button.active { color: var(--accent); }
+.theme-toggle button:hover,
+.palette-toggle button:hover { color: var(--accent); }
+.theme-toggle button.active,
+.palette-toggle button.active { color: var(--accent); }
 
 /* --- Homepage Posts --- */
 

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -4,9 +4,26 @@
 
     const STORAGE_KEY = 'theme-preference';
     const DYNAMIC_KEY = 'dynamic-colors';
+    const PALETTE_KEY = 'palette-preference';
 
     function getStoredTheme() {
         return localStorage.getItem(STORAGE_KEY) || 'auto';
+    }
+
+    function getStoredPalette() {
+        return localStorage.getItem(PALETTE_KEY) || 'voltage';
+    }
+
+    function applyPalette(palette) {
+        document.documentElement.setAttribute('data-palette', palette);
+        document.querySelectorAll('.palette-toggle button[data-palette]').forEach(btn => {
+            btn.classList.toggle('active', btn.dataset.palette === palette);
+        });
+    }
+
+    function setPalette(palette) {
+        localStorage.setItem(PALETTE_KEY, palette);
+        applyPalette(palette);
     }
 
     function resolveColorMode(theme) {
@@ -88,9 +105,17 @@
         const theme = getStoredTheme();
         applyTheme(theme);
 
+        applyPalette(getStoredPalette());
+
         document.querySelectorAll('.theme-toggle button[data-theme]').forEach(btn => {
             btn.addEventListener('click', () => {
                 setTheme(btn.dataset.theme);
+            });
+        });
+
+        document.querySelectorAll('.palette-toggle button[data-palette]').forEach(btn => {
+            btn.addEventListener('click', () => {
+                setPalette(btn.dataset.palette);
             });
         });
 


### PR DESCRIPTION
## Summary

Adds a **palette** dimension (`data-palette`) that's orthogonal to the existing light/dark/auto theme switch, so colour schemes can be swapped independently of mode.

- **Tokyo Night** is kept intact as a selectable palette.
- A new **Voltage** palette — carbon black / parchment base, neon spectrum per-type accents, cinnabar red lead — becomes the **default**.

## Changes

- **`assets/css/steno.css`** — Voltage dark/light/auto blocks layered via higher-specificity `[data-palette="voltage"]` selectors (source order irrelevant); per-type neon accents; brighter parchment light background; cinnabar accent bar for the top notification banner (Voltage-scoped, Tokyo keeps its subtle banner).
- **`assets/js/theme.js`** — palette read/apply/persist + toggle wiring; default `voltage`.
- **`_includes/partials/steno/footer.njk`** — Tokyo / Voltage palette toggle alongside the theme toggle.
- **`_includes/layouts/base.njk` / `home-steno.njk`** — inline head scripts set `data-palette` pre-paint to avoid flash.

## Palette mapping

| Type | Dark | Light |
|------|------|-------|
| post | cinnabar `#f73d3a` | `#d62b28` |
| essay | carrot orange `#f3961d` | `#b86a08` |
| link | electric aqua `#17ecff` | `#0e8b9c` |
| micro | neon violet `#bd48e8` | `#9a2fc0` |
| quote | spring green `#00ff95` | `#008f5a` |
| music | barbie pink `#ee388a` | `#d61c6e` |
| photography | bright indigo `#3740e7` | `#3038d0` |
| note | warm grey `#b0a8a4` | `#6a6360` |

Light-mode per-type accents are darkened from the raw neons for legibility on parchment.

## Test plan

- [x] Production build succeeds (`npm run build`)
- [x] Verified on local dev server (`npm run dev`) across both palettes and all three theme modes
- [ ] Confirm on Vercel preview before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)